### PR TITLE
Fix for the save directory not being located

### DIFF
--- a/ServerTools/ServerTools.csproj
+++ b/ServerTools/ServerTools.csproj
@@ -269,10 +269,8 @@
       <HintPath>..\7dtd-binaries\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\7 Days to Die Dedicated Server Experimental\7DaysToDieServer_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\7dtd-binaries\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ServerTools/src/Api.cs
+++ b/ServerTools/src/Api.cs
@@ -7,7 +7,7 @@ namespace ServerTools
 {
     public class API : IModApi
     {
-        public static string GamePath = GamePrefs.GetString(EnumGamePrefs.SaveGameFolder);
+        public static string GamePath = Path.GetFullPath($"{GameUtils.GetSaveGameDir()}{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..");
         public static string ConfigPath = string.Format("{0}/ServerTools", GamePath);
         public static int MaxPlayers = GamePrefs.GetInt(EnumGamePrefs.ServerMaxPlayerCount);
 

--- a/ServerTools/src/EntityCleanup/EntityCleanup.cs
+++ b/ServerTools/src/EntityCleanup/EntityCleanup.cs
@@ -48,7 +48,7 @@ namespace ServerTools
                             {
                                 Vector3 _vec = _entity.position;
                                 GameManager.Instance.World.RemoveEntity(_entity.entityId, EnumRemoveEntityReason.Despawned);
-                                EntityPlayer _douche = GameManager.Instance.World.GetClosestPlayer((int)_vec.x, (int)_vec.y, (int)_vec.z, 10, false);
+                                EntityPlayer _douche = GameManager.Instance.World.GetClosestPlayer((int)_vec.x, (int)_vec.y, (int)_vec.z, 10, double.MaxValue);
                                 if (_douche == null)
                                 {
                                     Log.Out(string.Format("[SERVERTOOLS] Entity cleanup: Removed minibike id {0}", _entity.entityId));


### PR DESCRIPTION
It seems like `GamePrefs.GetString(EnumGamePrefs.SaveGameFolder)` doesn't always produce the expected value since the latest update. I guess it depends on how the setting is configured. I was able to work around this using `Path.GetFullPath($"{GameUtils.GetSaveGameDir()}{Path.DirectorySeparatorChar}..{Path.DirectorySeparatorChar}..")` instead.

There are a few other changes to get it to compile.